### PR TITLE
Ensure Stockfish evals use white perspective

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,11 +186,14 @@ Summary: <a single-sentence overview of the whole game>
           const cp = /score cp (-?\d+)/.exec(lastInfoMsg);
           const mt = /score mate (-?\d+)/.exec(lastInfoMsg);
           if (currentScoreResolver) {
-            if (mt) currentScoreResolver('#' + mt[1]);
-            else if (cp) {
-              const s = (parseInt(cp[1], 10) / 100).toFixed(2);
-              currentScoreResolver(parseFloat(s) > 0 ? '+' + s : s);
-            } else currentScoreResolver('0.00');
+            if (mt) {
+              const val = mt[1].startsWith('-') ? -999 : 999;
+              currentScoreResolver(val);
+            } else if (cp) {
+              currentScoreResolver(parseInt(cp[1], 10));
+            } else {
+              currentScoreResolver(0);
+            }
             currentScoreResolver = null;
           }
         }
@@ -214,11 +217,6 @@ Summary: <a single-sentence overview of the whole game>
       $('#close-modal-btn').on('click', function(){ $('#error-modal').addClass('hidden'); });
 
       // ---------- Score helpers ----------
-      function parseEngineScoreToCp(scoreStr){
-        if (!scoreStr) return 0;
-        if (scoreStr[0] === '#') return scoreStr.includes('-') ? -999 : 999; // treat mate as huge
-        const n = parseFloat(scoreStr); if (isNaN(n)) return 0; return Math.round(n * 100);
-      }
       function cpToEvalBraced(cp){ const pawns = (cp/100).toFixed(2); return `{${cp > 0 ? '+'+pawns : pawns}}`; }
 
       // ---------- PGN normalization ----------
@@ -284,10 +282,10 @@ Summary: <a single-sentence overview of the whole game>
           const move = sanMoves[i]; temp.move(move);
           $('#progress-text').text('Analyzing move ' + (i + 1) + '/' + sanMoves.length + ': ' + move);
           $('#progress-bar').css('width', (((i + 1) / sanMoves.length) * 100) + '%');
-          const rawScore = await getScore(temp.fen()); // side-to-move POV
-          let cp = parseEngineScoreToCp(rawScore);
+          const stmCp = await getScore(temp.fen()); // side-to-move centipawns
+          let cp = stmCp;
           // Convert to WHITE-relative: if it's Black to move, negate
-          const isBlackToMove = (temp.turn() === 'b'); if (isBlackToMove) cp = -cp;
+          if (temp.turn() === 'b') cp = -cp;
           const evalStr = cpToEvalBraced(cp);
           annotatedPgn += (i % 2 === 0 ? prefix : '') + move + ' ' + evalStr + ' ';
         }


### PR DESCRIPTION
## Summary
- parse Stockfish bestmove info into raw centipawns
- always convert evaluation to white's POV before bracing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6701285883338feecbf285c4fb05