### PR TITLE
Set default engine threads and hash, disable configuration inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,14 @@
       <label for="pgn-input" class="block mb-2 font-semibold text-gray-300">Paste PGN here</label>
       <textarea id="pgn-input" rows="12" class="w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
     </div>
-    <div class="flex gap-4">
-      <div class="flex-1">
+      <div class="flex gap-4">
+        <div class="flex-1">
         <label for="threads-input" class="block mb-2 font-semibold text-gray-300">Threads</label>
-        <input id="threads-input" type="number" min="1" value="1" class="w-full p-2 rounded-lg form-input" />
+        <input id="threads-input" type="number" min="1" value="3" class="w-full p-2 rounded-lg form-input" disabled />
       </div>
       <div class="flex-1">
         <label for="hash-input" class="block mb-2 font-semibold text-gray-300">Hash (MB)</label>
-        <input id="hash-input" type="number" min="1" value="16" class="w-full p-2 rounded-lg form-input" />
+        <input id="hash-input" type="number" min="1" value="64" class="w-full p-2 rounded-lg form-input" disabled />
       </div>
     </div>
     <button id="analyze-pgn-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary" disabled>
@@ -187,8 +187,8 @@ Summary: <a single-sentence overview of the whole game>
       function configureEngineOptions() {
         engineReady = false;
         $('#analyze-pgn-btn').prop('disabled', true).text('Loading Engine...');
-        const threads = parseInt($('#threads-input').val(), 10) || 1;
-        const hash = parseInt($('#hash-input').val(), 10) || 16;
+        const threads = parseInt($('#threads-input').val(), 10) || 3;
+        const hash = parseInt($('#hash-input').val(), 10) || 64;
         const options = { Threads: threads, Hash: hash };
         Object.entries(options).forEach(([name, value]) => {
           engineWorker.postMessage(`setoption name ${name} value ${value}`);
@@ -223,7 +223,6 @@ Summary: <a single-sentence overview of the whole game>
       };
       engineWorker.postMessage('uci');
       configureEngineOptions();
-      $('#threads-input, #hash-input').on('change', configureEngineOptions);
 
       function waitForEngineReady() {
         return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- Default Stockfish threads set to 3 and hash to 64 in the UI and engine config
- Disabled thread and hash inputs to prevent user modification
- Simplified engine initialization by removing unused change listeners

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c01d2bc0908333b92cbb24c00f5f16