### PR TITLE
Use movetime for Stockfish engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ Summary: <a single-sentence overview of the whole game>
       // ====== Stockfish (same-origin Worker) ======
       const LOCAL_ENGINE = 'engine/stockfish-nnue-16-single.js';
       // Configure engine search: set either { depth: N } or { movetime: ms }
-      const ENGINE_GO_OPTIONS = { depth: 15 }; // or e.g., { movetime: 3000 }
+      const ENGINE_GO_OPTIONS = { movetime: 1500 }; // or e.g., { movetime: 3000 }
       let engineWorker = new Worker(LOCAL_ENGINE);
       let engineReady = false;
       let lastInfoMsg = '';


### PR DESCRIPTION
## Summary
- Switch Stockfish engine configuration to use `movetime: 1500` instead of fixed depth for per-move timing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c032129f7c83339892d0a5ad2bdeab