### PR TITLE
Use win probability instead of centipawns

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@ Summary: <a single-sentence overview of the whole game>
                 <!-- marker -->
                 <div id="eval-marker" class="absolute top-1/2 -translate-y-1/2 w-1.5 h-4 bg-blue-500 rounded" style="left:50%"></div>
               </div>
-              <div id="eval-number" class="text-sm font-bold min-w-[3.5rem] text-right">+0.00</div>
+              <div id="eval-number" class="text-sm font-bold min-w-[3.5rem] text-right">50%</div>
             </div>
           </div>
 
@@ -229,7 +229,7 @@ Summary: <a single-sentence overview of the whole game>
       let game = new Chess();
       let movesWithAnalysis = [];
       let currentMoveIndex = -1;
-      let evalSeries = []; // WHITE-relative cp per ply (from comments {eval})
+      let probSeries = []; // WHITE win probability per ply (0..1)
 
       const classificationStyles = {
         'book': 'text-blue-400','good':'text-green-400','okay':'text-green-400','excellent':'text-teal-300','great':'text-teal-300',
@@ -242,6 +242,17 @@ Summary: <a single-sentence overview of the whole game>
 
       // ---------- Score helpers ----------
       function cpToEvalBraced(cp){ const pawns = (cp/100).toFixed(2); return `{${cp > 0 ? '+'+pawns : pawns}}`; }
+
+      function cpToProb(cp){ return 1 / (1 + Math.exp(-cp / 173)); }
+
+      function scoreToCheckmateProb(score) {
+        if (!score || typeof score.value !== 'number') return 0.5;
+        if (score.type === 'mate') {
+          const sign = score.value >= 0 ? 1 : -1;
+          return cpToProb(sign * 10000);
+        }
+        return cpToProb(score.value);
+      }
 
       // ---------- PGN normalization ----------
       function normalizePgn(raw, opts) {
@@ -302,6 +313,7 @@ Summary: <a single-sentence overview of the whole game>
         const sanMoves = game.history(); let annotatedPgn = '';
         const headerBlock = buildHeaderTagBlock(game); if (headerBlock) annotatedPgn = headerBlock + '\n\n';
         const temp = new Chess();
+        probSeries = [];
         for (let i = 0; i < sanMoves.length; i++) {
           const moveNumber = Math.floor(i / 2) + 1; const prefix = (i % 2 === 0) ? (moveNumber + '. ') : '';
           const move = sanMoves[i];
@@ -322,10 +334,12 @@ Summary: <a single-sentence overview of the whole game>
             let m = score.value; // mate in N from side to move
             if (temp.turn() === 'b') m = -m; // convert to WHITE-relative
             evalStr = `{#${m}}`;
+            probSeries.push(scoreToCheckmateProb({ type: 'mate', value: m }));
           } else {
             let cp = score.value; // centipawns from side to move
             if (temp.turn() === 'b') cp = -cp; // convert to WHITE-relative
             evalStr = cpToEvalBraced(cp);
+            probSeries.push(scoreToCheckmateProb({ type: 'cp', value: cp }));
           }
           annotatedPgn += (i % 2 === 0 ? prefix : '') + move + ' ' + evalStr + ' ';
         }
@@ -372,7 +386,8 @@ Summary: <a single-sentence overview of the whole game>
 
         const gameMoves = game.history({ verbose: true }); let cursor = 0;
         movesWithAnalysis = gameMoves.map(m => { let analysis = null; if (cursor < parsed.moves.length && parsed.moves[cursor].san === m.san) analysis = parsed.moves[cursor++]; return { ...m, analysis, criticalMoment: parsed.criticalMoments[m.san] }; });
-        evalSeries = movesWithAnalysis.map(m => parseEvalToCp(m.analysis && m.analysis.evaluation));
+        probSeries = movesWithAnalysis.map(m => parseEvalToProb(m.analysis && m.analysis.evaluation));
+        movesWithAnalysis.forEach((mv, i) => { mv.prob = probSeries[i]; });
 
         // Summary text
         const summary = parsed.summary || '';
@@ -411,12 +426,23 @@ Summary: <a single-sentence overview of the whole game>
       // Convert evaluation string like "{+0.23}", "{-1.10}", "{#3}" (WHITE-relative already)
       function parseEvalToCp(evalStr) { if (!evalStr) return null; const s = String(evalStr).replace(/[{}\s]/g,''); if (!s) return null; if (s[0] === '#') return s.includes('-') ? -999 : 999; const num = parseFloat(s); if (isNaN(num)) return null; return Math.round(num * 100); }
 
+      function parseEvalToProb(evalStr) {
+        const cp = parseEvalToCp(evalStr);
+        if (cp == null) return null;
+        return cpToProb(cp);
+      }
+
+      function formatProbability(p) {
+        if (p == null) return '';
+        return (p * 100).toFixed(1) + '%';
+      }
+
       // ====== Rendering ======
       function renderMoveList() {
         const c = $('#move-analysis-container').empty();
         movesWithAnalysis.forEach((mv, i) => {
           const n = mv.color === 'w' ? (Math.floor(i / 2) + 1) + '.' : '';
-          const evalHtml = mv.analysis && mv.analysis.evaluation ? '<span class="font-mono text-xs text-gray-400 ml-2">' + mv.analysis.evaluation + '</span>' : '';
+          const evalHtml = mv.prob != null ? '<span class="font-mono text-xs text-gray-400 ml-2">' + formatProbability(mv.prob) + '</span>' : '';
           const html =
             '<div class="move-item p-2 cursor-pointer" data-move-index="' + i + '">' +
               '<div class="flex items-baseline gap-3">' +
@@ -458,12 +484,11 @@ Summary: <a single-sentence overview of the whole game>
         const number = document.getElementById('eval-number');
         const bar = document.getElementById('eval-bar');
         if (!marker || !number || !bar) return;
-        let cp = 0; if (idx >= 0 && idx < evalSeries.length && evalSeries[idx] != null) cp = evalSeries[idx];
-        const W = bar.clientWidth || 100; const min = -500, max = 500; const clamped = Math.max(min, Math.min(max, cp));
-        const t = 1 - (clamped - min) / (max - min); // 0..1 left→right (white advantage left)
+        let p = 0.5; if (idx >= 0 && idx < probSeries.length && probSeries[idx] != null) p = probSeries[idx];
+        const W = bar.clientWidth || 100;
+        const t = 1 - p; // 0..1 left→right (white advantage left)
         marker.style.left = (t * W) + 'px';
-        const pawns = (cp / 100).toFixed(2);
-        number.textContent = (cp > 0 ? '+' : (cp < 0 ? '' : '+')) + pawns;
+        number.textContent = formatProbability(p);
       }
 
       function goToMove(idx) {


### PR DESCRIPTION
## Summary
- convert Stockfish scores into win probabilities with new `scoreToCheckmateProb`
- track probability series during analysis and when parsing AI review
- display probabilities in move list and evaluation bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0514ce4008333908d82cf053be648