### PR TITLE
Shorten review comments scroll area by one third

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,8 @@ Output exactly one line per half-move as specified, followed by a final Summary:
         const topPadding = headerHidden ? 8 : 16;
         // On mobile: place analysis below; give it remaining height
         let target = vh - (boardH + controlsH + topPadding + 24);
-        if (target < 180) target = 180; // minimum height
+        target = Math.floor(target * 2 / 3); // make scrollable area 1/3 shorter
+        if (target < 120) target = 120; // minimum height after reduction
         scroll.style.maxHeight = target + 'px';
         scroll.style.height = target + 'px';
       }


### PR DESCRIPTION
## Summary
- Reduce move analysis scroll height by one third in `adjustAnalysisHeight` for a more compact review comments pane

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0925eafbc833392cd831030c74488