### PR TITLE
Display mate evaluations verbatim in move list

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,7 +531,12 @@ Output exactly one line per half-move as specified, followed by a final Summary:
         const c = $('#move-analysis-container').empty();
         movesWithAnalysis.forEach((mv, i) => {
           const n = mv.color === 'w' ? (Math.floor(i / 2) + 1) + '.' : '';
-          const evalHtml = mv.prob != null ? '<span class="font-mono text-xs text-gray-400 ml-2">' + formatProbability(mv.prob) + '</span>' : '';
+          let evalHtml = '';
+          if (mv.analysis && mv.analysis.evaluation && mv.analysis.evaluation.includes('#')) {
+            evalHtml = '<span class="font-mono text-xs text-gray-400 ml-2">' + mv.analysis.evaluation + '</span>';
+          } else if (mv.prob != null) {
+            evalHtml = '<span class="font-mono text-xs text-gray-400 ml-2">' + formatProbability(mv.prob) + '</span>';
+          }
           const html =
             '<div class="move-item p-2 cursor-pointer" data-move-index="' + i + '">' +
               '<div class="flex items-baseline gap-3">' +


### PR DESCRIPTION
## Summary
- Show mate evaluations such as `{#-3}` directly when provided in move analysis
- Fall back to probability display when no mate score is present

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b46c0d08333990194600fb9ff9e