### PR TITLE
Use hardware concurrency for Stockfish threads

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,8 @@ Summary: <a single-sentence overview of the whole game>
       function configureEngineOptions() {
         engineReady = false;
         $('#analyze-pgn-btn').prop('disabled', true).text('Loading Engine...');
-        const options = { Threads: 3, Hash: 64 };
+        const threadCount = navigator.hardwareConcurrency || 3;
+        const options = { Threads: threadCount, Hash: 64 };
         Object.entries(options).forEach(([name, value]) => {
           engineWorker.postMessage(`setoption name ${name} value ${value}`);
         });


### PR DESCRIPTION
## Summary
- determine engine thread count from `navigator.hardwareConcurrency` with fallback to 3
- send the dynamic thread count to the worker via `setoption`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b8d5c85483338647194fbea4fd5a