### PR TITLE
Reduce text box size and darken background

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     .btn-primary:disabled { background-color: #374151; cursor: not-allowed; }
     .btn-secondary { background-color: #374151; transition: background-color: 0.2s; }
     .btn-secondary:hover { background-color: #4b5563; }
-    textarea.form-input { background-color: #0b0e15; border-color: #364152; color: #e5e7eb; }
+    textarea.form-input { background-color: #2d2d2d; border-color: #364152; color: #e5e7eb; }
     textarea.form-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35); outline: none; }
     .step-indicator { background-color: #273043; }
     .step-indicator.active { background-color: #3b82f6; }
@@ -54,7 +54,7 @@
     <p class="text-center text-gray-400">Paste your game's PGN below. The engine will run in your browser to add move evaluations.</p>
     <div>
       <label for="pgn-input" class="block mb-2 font-semibold text-gray-300">Paste PGN here</label>
-      <textarea id="pgn-input" rows="12" class="w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
+      <textarea id="pgn-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
     </div>
     <button id="analyze-pgn-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary" disabled>
       Loading Engine...
@@ -72,7 +72,7 @@
     </div>
     <div>
       <label for="stockfish-output" class="block mb-2 font-semibold text-gray-300">1. Copy the prompt + annotated PGN below</label>
-      <textarea id="stockfish-output" rows="14" class="w-full p-3 rounded-lg form-input font-mono text-sm" readonly></textarea>
+      <textarea id="stockfish-output" rows="7" class="w-full p-3 rounded-lg form-input font-mono text-sm" readonly></textarea>
       <button id="copy-stockfish-btn" class="w-full mt-2 py-2 px-4 font-semibold text-white rounded-lg btn-secondary">Copy to Clipboard</button>
     </div>
     <div class="p-4 bg-emerald-900/40 border border-emerald-700 rounded-lg">
@@ -101,7 +101,7 @@ Summary: <a single-sentence overview of the whole game>
     <p class="text-center text-gray-400">Paste the full text from the AI (PGN + comments) or just comments like <em>e4 - {53%} Good: ...</em>. The braces should contain win-probability percentages. Include the final line starting with <strong>Summary:</strong>.</p>
     <div>
       <label for="final-analysis-input" class="block mb-2 font-semibold text-gray-300">Paste complete analysis here</label>
-      <textarea id="final-analysis-input" rows="12" class="w-full p-3 rounded-lg form-input" placeholder="e4 - {53%} Good: A classical opening move...\n...\nSummary: Black won after a decisive kingside attack."></textarea>
+      <textarea id="final-analysis-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="e4 - {53%} Good: A classical opening move...\n...\nSummary: Black won after a decisive kingside attack."></textarea>
     </div>
     <button id="generate-review-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary">
       Generate Interactive Review


### PR DESCRIPTION
## Summary
- Shrink PGN, Stockfish, and final analysis text areas to half their previous height
- Use a dark gray background for text areas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4af27860483338387183949acaa4a