### PR TITLE
Remove redundant instructional section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,21 +75,6 @@
       <textarea id="stockfish-output" rows="7" class="w-full p-3 rounded-lg form-input font-mono text-sm" readonly></textarea>
       <button id="copy-stockfish-btn" class="w-full mt-2 py-2 px-4 font-semibold text-white rounded-lg btn-secondary">Copy to Clipboard</button>
     </div>
-    <div class="p-4 bg-emerald-900/40 border border-emerald-700 rounded-lg">
-      <h3 class="font-semibold text-emerald-300">2. What this button copies</h3>
-      <div class="mt-2 p-2 bg-black/40 rounded">
-        <p class="text-xs text-gray-300 whitespace-pre-wrap font-mono">
-Analyze the following PGN, which includes Stockfish win-probability evaluations in braces {} (percentage is White's chance of winning). For each move, write exactly one line using this format:
-
-move - {Stockfish win probability} classification: comment
-
-Keep the evaluation exactly as shown in the PGN (e.g., {52%}, {78%}, {0%}). For the classification, use a single word (e.g., Book, Good, Brilliant, Inaccuracy, Mistake, Blunder, Forced, Misclick??). Do not add move numbers, markdown, bullet points, or extra formatting.
-
-At the very end, add one line starting with:
-Summary: <a single-sentence overview of the whole game>
-        </p>
-      </div>
-    </div>
     <button id="goto-step3-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary" disabled>
       Continue to Final Step
     </button>


### PR DESCRIPTION
## Summary
- remove "What this button copies" section from step 2 instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b41e7e688333ba4cd9e61150e729