### PR TITLE
feat: expand summary parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,13 +488,14 @@ Do not use any extra headings, bullet points, or other formatting in your main o
 
       // Parse analysis lines with optional {eval} and final Summary:
       function parseAnalysis(text) {
-        const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = '';
+        const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = ''; let inSummary = false;
         const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z?]+)\s*:\s*(.*)/;
         const criticalMomentRegex = /^Critical Moment:\s*(.*)/i;
         const summaryHeaderRegex = /^\s*\*\*(Strengths|Recurring Mistakes|Top 3 Takeaways)\*\*/i;
-        const summaryLineRegex = /^Summary:\s*(.*)/i;
+        const summaryLineRegex = /^Summary[^:]*:\s*(.*)/i;
         lines.forEach(line => {
-          const sl = line.match(summaryLineRegex); if (sl) { summaryLine = sl[1].trim(); return; }
+          if (inSummary) { if (line.trim()) summaryLine += ' ' + line.trim(); return; }
+          const sl = line.match(summaryLineRegex); if (sl) { summaryLine = sl[1].trim(); inSummary = true; return; }
           const m = line.match(moveRegex);
           if (m) {
             const san = m[1];


### PR DESCRIPTION
## Summary
- broaden summary detection to accept any line starting with `Summary`
- accumulate multi-line summaries following the summary header

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c59313175483338c463c7550182e6a