### PR TITLE
Handle Stockfish engine load failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,18 @@
       const LOCAL_ENGINE = 'engine/stockfish-nnue-16-single.js';
       // Configure engine search: set either { depth: N } or { movetime: ms }
       const ENGINE_GO_OPTIONS = { depth: 16 }; // or e.g., { depth: 20 }
-      let engineWorker = new Worker(LOCAL_ENGINE);
+      let engineWorker = null;
+      try {
+        engineWorker = new Worker(LOCAL_ENGINE);
+      } catch (err) {
+        showError('Failed to load Stockfish engine.');
+        $('#analyze-pgn-btn').prop('disabled', true).text('Engine Load Error');
+        return;
+      }
+      engineWorker.onerror = function () {
+        showError('Failed to load Stockfish engine.');
+        $('#analyze-pgn-btn').prop('disabled', true).text('Engine Load Error');
+      };
       let engineReady = false;
       let lastInfoMsg = '';
       let currentScoreResolver = null;


### PR DESCRIPTION
## Summary
- add try/catch and error handler around Stockfish worker to surface load failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f09e5e348333b2a19dbcfa4865d8