### PR TITLE
Add Stockfish initialization timeout

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
           $('#analyze-pgn-btn').prop('disabled', true).text('Engine Load Error');
         };
       let engineReady = false;
+      let engineInitTimeout = null;
       let lastInfoMsg = '';
       let currentScoreResolver = null;
 
@@ -257,6 +258,7 @@ Do not use any extra headings, bullet points, or other formatting in your main o
         const msg = String(e.data || '');
         if (msg === 'readyok') {
           engineReady = true;
+          clearTimeout(engineInitTimeout);
           $('#analyze-pgn-btn').prop('disabled', false).text('Run Stockfish Analysis');
         } else if (msg.startsWith('info depth')) {
           lastInfoMsg = msg;
@@ -277,6 +279,13 @@ Do not use any extra headings, bullet points, or other formatting in your main o
       };
       engineWorker.postMessage('uci');
       configureEngineOptions();
+      engineInitTimeout = setTimeout(() => {
+        if (!engineReady) {
+          engineWorker.terminate();
+          showError('Stockfish failed to initialize');
+          $('#analyze-pgn-btn').prop('disabled', false).text('Engine Load Error');
+        }
+      }, 10000);
 
       function waitForEngineReady() {
         return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- Add timeout when initializing Stockfish and show user-friendly error if it fails
- Terminate worker and reset button on timeout
- Clear timeout when engine becomes ready

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c5fac8c3c4833391b8dc4662d85f11