### PR TITLE
Fix regex escaping in summary classification handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@ Do not use any extra headings, bullet points, or other formatting in your main o
         let html = formatText(s);
         Object.keys(classificationStyles).forEach(k => {
           if (k === 'default') return;
-          const escaped = k.replace(/[.*+?^${}()|[\]\]/g, '\\$&');
+          const escaped = k.replace(/[.*+?^${}()|[\]\\]/g, '\$&');
           const regex = new RegExp('\\b' + escaped + '\\b', 'gi');
           html = html.replace(regex, m => '<span class="' + getStyleForClassification(k) + '">' + m + '</span>');
         });


### PR DESCRIPTION
## Summary
- correct regex for escaping classification keywords to avoid invalid regular expression syntax

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fce514288333ae04c6add9d849a8