### PR TITLE
Add user-configurable engine settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
     .btn-primary:disabled { background-color: #374151; cursor: not-allowed; }
     .btn-secondary { background-color: #374151; transition: background-color: 0.2s; }
     .btn-secondary:hover { background-color: #4b5563; }
-    textarea.form-input { background-color: #2d2d2d; border-color: #364152; color: #e5e7eb; }
-    textarea.form-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35); outline: none; }
+    textarea.form-input, input.form-input { background-color: #2d2d2d; border-color: #364152; color: #e5e7eb; }
+    textarea.form-input:focus, input.form-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35); outline: none; }
     .step-indicator { background-color: #273043; }
     .step-indicator.active { background-color: #3b82f6; }
   </style>
@@ -38,7 +38,6 @@
   <!-- Header (hidden on final screen) -->
   <header id="app-header" class="text-center mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold text-white">AI Chess Reviewer</h1>
-    <p class="text-gray-400 mt-2">A new way to get deep, AI-powered analysis of your games.</p>
   </header>
 
   <!-- Step Indicators -->
@@ -55,6 +54,20 @@
     <div>
       <label for="pgn-input" class="block mb-2 font-semibold text-gray-300">Paste PGN here</label>
       <textarea id="pgn-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
+    </div>
+    <div class="flex justify-center gap-2 text-sm">
+      <div class="flex flex-col items-center">
+        <label for="depth-input" class="text-gray-300">Depth</label>
+        <input id="depth-input" type="number" min="1" value="20" class="w-16 p-1 rounded form-input text-center"/>
+      </div>
+      <div class="flex flex-col items-center">
+        <label for="threads-input" class="text-gray-300">Threads</label>
+        <input id="threads-input" type="number" min="1" class="w-16 p-1 rounded form-input text-center"/>
+      </div>
+      <div class="flex flex-col items-center">
+        <label for="hash-input" class="text-gray-300">Memory</label>
+        <input id="hash-input" type="number" min="1" value="256" class="w-16 p-1 rounded form-input text-center"/>
+      </div>
     </div>
     <button id="analyze-pgn-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary" disabled>
       Loading Engine...
@@ -142,6 +155,9 @@
 
   <script>
     $(function () {
+      const defaultThreads = navigator.hardwareConcurrency || 3;
+      $('#threads-input').val(defaultThreads);
+
       // ====== Stockfish (same-origin Worker) ======
       const LOCAL_ENGINE = 'engine/stockfish-nnue-16-single.js';
       // Configure engine search: set either { depth: N } or { movetime: ms }
@@ -165,11 +181,18 @@
       let lastInfoMsg = '';
       let currentScoreResolver = null;
 
-      function configureEngineOptions() {
+      function configureEngineOptions(initial = false) {
         engineReady = false;
-        $('#analyze-pgn-btn').prop('disabled', true).text('Loading Engine...');
-        const threadCount = navigator.hardwareConcurrency || 3;
-        const options = { Threads: threadCount , Hash: 256 };
+        if (initial) {
+          $('#analyze-pgn-btn').prop('disabled', true).text('Loading Engine...');
+        } else {
+          $('#analyze-pgn-btn').prop('disabled', true);
+        }
+        const depthVal = parseInt($('#depth-input').val(), 10) || 20;
+        const threadVal = parseInt($('#threads-input').val(), 10) || (navigator.hardwareConcurrency || 3);
+        const hashVal = parseInt($('#hash-input').val(), 10) || 256;
+        ENGINE_GO_OPTIONS.depth = depthVal;
+        const options = { Threads: threadVal, Hash: hashVal };
         Object.entries(options).forEach(([name, value]) => {
           engineWorker.postMessage(`setoption name ${name} value ${value}`);
         });
@@ -278,7 +301,7 @@ Do not use any extra headings, bullet points, or other formatting in your main o
         }
       };
       engineWorker.postMessage('uci');
-      configureEngineOptions();
+      configureEngineOptions(true);
       engineInitTimeout = setTimeout(() => {
         if (!engineReady) {
           engineWorker.terminate();
@@ -402,6 +425,7 @@ Do not use any extra headings, bullet points, or other formatting in your main o
       });
 
       async function runStockfishAnalysis() {
+        configureEngineOptions();
         await waitForEngineReady();
         const sanMoves = game.history(); let annotatedPgn = '';
         const headerBlock = buildHeaderTagBlock(game); if (headerBlock) annotatedPgn = headerBlock + '\n\n';


### PR DESCRIPTION
## Summary
- Allow users to set Stockfish depth, thread count, and hash memory from the initial page
- Remove tagline text from header for a cleaner layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a15330c8333a905a277b13ecf8c