### PR TITLE
Allow whitespace before summary line

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,9 @@ Do not use any extra headings, bullet points, or other formatting in your main o
         const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z?]+)\s*:\s*(.*)/;
         const criticalMomentRegex = /^Critical Moment:\s*(.*)/i;
         const summaryHeaderRegex = /^\s*\*\*(Strengths|Recurring Mistakes|Top 3 Takeaways)\*\*/i;
-        const summaryLineRegex = /^Summary[^:]*:\s*(.*)/i;
+        // Allow leading whitespace before "Summary:" to handle AI outputs
+        // that may indent or space the final summary line.
+        const summaryLineRegex = /^\s*Summary[^:]*:\s*(.*)/i;
         lines.forEach(line => {
           if (inSummary) { if (line.trim()) summaryLine += ' ' + line.trim(); return; }
           const sl = line.match(summaryLineRegex); if (sl) { summaryLine = sl[1].trim(); inSummary = true; return; }


### PR DESCRIPTION
## Summary
- Handle leading whitespace before the final `Summary:` line so pasted AI reviews are parsed reliably

## Testing
- `node - <<'NODE'
const summaryLineRegex = /^\s*Summary[^:]*:\s*(.*)/i;
const lines = [
  "Summary: 40 Total Good = 1 Great, 28 Good, 2 Book, 9 Forced; 5 Total Bad = 3 Inaccuracies, 2 Mistakes. Accuracy: 40 / 45 * 100 = 89%. After your opponent's unsound opening sacrifice gave you a winning position, a few mistakes allowed the game to become complicated, but you ultimately capitalized on their final blunder and converted the winning endgame.",
  "  Summary: 40 Total Good = 1 Great, 28 Good, 2 Book, 9 Forced; 5 Total Bad = 3 Inaccuracies, 2 Mistakes. Accuracy: 40 / 45 * 100 = 89%. After your opponent's unsound opening sacrifice gave you a winning position, a few mistakes allowed the game to become complicated, but you ultimately capitalized on their final blunder and converted the winning endgame."
];
lines.forEach(line => {
  const m = line.match(summaryLineRegex);
  console.log(m && m[1]);
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c688173ca88333b7dbf1688ecd76a2