### PR TITLE
Highlight accuracy percentages in summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,12 @@ Before providing any output, you must perform these final checks after generatin
           html = html.replace(regex, m => '<span class="' + getStyleForClassification(k) + '">' + m + '</span>');
         });
 
+        // Highlight accuracy percentages (e.g., "Accuracy: 65%" or "65% accuracy")
+        html = html.replace(/(accuracy\s*:?\s*)(\d+(?:\.\d+)?%)/ig,
+          (m, p1, p2) => p1 + '<strong class="text-yellow-400">' + p2 + '</strong>');
+        html = html.replace(/(\d+(?:\.\d+)?%)\s*(accuracy)/ig,
+          (m, p1, p2) => '<strong class="text-yellow-400">' + p1 + '</strong> ' + p2);
+
         if (totalGood) {
           html = html.replace('@@TOTAL_GOOD@@', '<strong class="text-yellow-400">' + totalGood + '</strong>');
         }


### PR DESCRIPTION
## Summary
- highlight accuracy percentages in the summary by wrapping numbers and percent signs in bold yellow text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cbc878e08333a8fb92fff6577a1a