### PR TITLE
Improve parsing of AI comments with punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,9 @@ Before providing any output, you must perform a final check after generating the
         default: ''
       };
       function getStyleForClassification(c) {
-        return classificationStyles[(c || '').toLowerCase().replace(/\s/g,'')] || classificationStyles['default'];
+        return classificationStyles[(c || '')
+          .toLowerCase()
+          .replace(/[\s!?]/g, '')] || classificationStyles['default'];
       }
       let selectedSquare = null;
       function clearSelected() {
@@ -652,7 +654,7 @@ Before providing any output, you must perform a final check after generating the
       // Parse analysis lines with optional {eval} and final Summary:
       function parseAnalysis(text) {
         const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = ''; let inSummary = false;
-        const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z?]+)\s*:\s*(.*)/;
+        const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z!?\s]+)\s*:\s*(.*)/;
         const criticalMomentRegex = /^Critical Moment:\s*(.*)/i;
         const summaryHeaderRegex = /^\s*\*\*(Strengths|Recurring Mistakes|Top 3 Takeaways)\*\*/i;
         // Allow leading whitespace before "Summary:" to handle AI outputs


### PR DESCRIPTION
## Summary
- Allow comment classifications like `Good!` or `Mistake?` by relaxing the parsing regex
- Strip spaces and punctuation when mapping classifications to styles

## Testing
- `node <<'NODE'
const text = `e4 - {53%} Good!: example move
Nc6 - {47%} Mistake?: comment
Summary: Test`;
const cpToProb=cp=>1/(1+Math.exp(-cp/173));
function parseEvalToCp(evalStr){ if(!evalStr) return null; const s=String(evalStr).replace(/[{}\s]/g,''); if(!s) return null; if(s[0]=='#') return s.includes('-')? -999:999; const num=parseFloat(s); if(isNaN(num)) return null; return Math.round(num*100); }
function parseEvalToProb(evalStr){ if(!evalStr) return null; const s=String(evalStr).replace(/[{}\s]/g,''); if(!s) return null; if(s[0]=='#'){ const m=parseInt(s.slice(1),10); if(isNaN(m)) return null; if(m===0) return null; return m>0?1:0;} if(s.endsWith('%')){ const num=parseFloat(s.slice(0,-1)); if(isNaN(num)) return null; return num/100;} const cp=parseEvalToCp(evalStr); if(cp==null) return null; return cpToProb(cp); }
function parseAnalysis(text){ const lines=text.split('\n'); const parsedMoves=[]; const moveRegex=/^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z!?\s]+)\s*:\s*(.*)/; lines.forEach(line=>{ const m=line.match(moveRegex); if(m){ parsedMoves.push({san:m[1], classification:m[3].trim()}); }}); return parsedMoves; }
console.log(parseAnalysis(text));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c74e5f783083338ac618e82cdffb5d