### PR TITLE
feat: enhance best-move evaluation display

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,9 @@
         let currentScoreResolver = null;
         let showBestMove = false;
         let bestMoveSquares = null;
+        let arrowCanvas = null;
+        let arrowCtx = null;
+        let lastBestMove = null;
 
       function configureEngineOptions() {
         engineReady = false;
@@ -557,11 +560,11 @@ Before providing any output, you must perform a final check after generating the
             currentScoreResolver = resolve; lastInfoMsg = '';
             engineWorker.postMessage('position fen ' + fen);
             const o = opts || ENGINE_GO_OPTIONS || {};
-            let cmd;
-            if (o.depth != null) cmd = 'go depth ' + o.depth;
-            else if (o.movetime != null) cmd = 'go movetime ' + o.movetime;
-            else cmd = 'go depth 15';
-            engineWorker.postMessage(cmd);
+            const parts = ['go'];
+            if (o.depth != null) parts.push('depth ' + o.depth);
+            if (o.movetime != null) parts.push('movetime ' + o.movetime);
+            if (parts.length === 1) parts.push('depth 15');
+            engineWorker.postMessage(parts.join(' '));
           });
         }
 
@@ -570,19 +573,75 @@ Before providing any output, you must perform a final check after generating the
             bestMoveSquares.forEach(sq => $('#board .square-' + sq).removeClass('selected'));
             bestMoveSquares = null;
           }
+          if (arrowCtx && arrowCanvas) arrowCtx.clearRect(0, 0, arrowCanvas.width, arrowCanvas.height);
+          lastBestMove = null;
+        }
+
+        function ensureArrowCanvas() {
+          const boardEl = document.getElementById('board');
+          if (!boardEl) return;
+          if (!arrowCanvas) {
+            arrowCanvas = document.createElement('canvas');
+            arrowCanvas.id = 'best-move-arrow';
+            arrowCanvas.style.position = 'absolute';
+            arrowCanvas.style.top = '0';
+            arrowCanvas.style.left = '0';
+            arrowCanvas.style.pointerEvents = 'none';
+            boardEl.style.position = 'relative';
+            boardEl.appendChild(arrowCanvas);
+            arrowCtx = arrowCanvas.getContext('2d');
+          }
+          arrowCanvas.width = boardEl.clientWidth;
+          arrowCanvas.height = boardEl.clientHeight;
+        }
+
+        function drawBestMoveArrow(from, to) {
+          ensureArrowCanvas();
+          if (!arrowCtx) return;
+          arrowCtx.clearRect(0, 0, arrowCanvas.width, arrowCanvas.height);
+          const boardEl = document.getElementById('board');
+          const boardRect = boardEl.getBoundingClientRect();
+          const fromEl = document.querySelector('#board .square-' + from);
+          const toEl = document.querySelector('#board .square-' + to);
+          if (!fromEl || !toEl) return;
+          const fromRect = fromEl.getBoundingClientRect();
+          const toRect = toEl.getBoundingClientRect();
+          const fx = fromRect.left + fromRect.width / 2 - boardRect.left;
+          const fy = fromRect.top + fromRect.height / 2 - boardRect.top;
+          const tx = toRect.left + toRect.width / 2 - boardRect.left;
+          const ty = toRect.top + toRect.height / 2 - boardRect.top;
+          const lineWidth = arrowCanvas.width / 35;
+          const headlen = arrowCanvas.width / 20;
+          arrowCtx.strokeStyle = '#fbbf24';
+          arrowCtx.fillStyle = '#fbbf24';
+          arrowCtx.lineWidth = lineWidth;
+          arrowCtx.lineCap = 'round';
+          arrowCtx.beginPath();
+          arrowCtx.moveTo(fx, fy);
+          arrowCtx.lineTo(tx, ty);
+          arrowCtx.stroke();
+          const angle = Math.atan2(ty - fy, tx - fx);
+          arrowCtx.beginPath();
+          arrowCtx.moveTo(tx, ty);
+          arrowCtx.lineTo(tx - headlen * Math.cos(angle - Math.PI / 6), ty - headlen * Math.sin(angle - Math.PI / 6));
+          arrowCtx.lineTo(tx - headlen * Math.cos(angle + Math.PI / 6), ty - headlen * Math.sin(angle + Math.PI / 6));
+          arrowCtx.closePath();
+          arrowCtx.fill();
         }
 
         function showBestMoveForCurrentPosition() {
           if (!showBestMove || !engineReady) return;
           const fen = game ? game.fen() : null;
           if (!fen) return;
-          getScore(fen).then(res => {
+          getScore(fen, { depth: Math.max(ENGINE_GO_OPTIONS.depth, 18), movetime: 2000 }).then(res => {
             if (!showBestMove || !res || !res.bestmove) return;
             const from = res.bestmove.substring(0, 2);
             const to = res.bestmove.substring(2, 4);
+            lastBestMove = res.bestmove;
             clearBestMoveHighlight();
             $('#board .square-' + from).addClass('selected');
             $('#board .square-' + to).addClass('selected');
+            drawBestMoveArrow(from, to);
             bestMoveSquares = [from, to];
           });
         }
@@ -650,7 +709,14 @@ Before providing any output, you must perform a final check after generating the
             pieceTheme: 'https://chessboardjs.com/img/chesspieces/wikipedia/{piece}.png'
           });
           $('#board').on('click', '.square-55d63', function(){ handleSquareClick($(this).data('square')); });
-          $(window).on('resize', function(){ board.resize(); adjustAnalysisHeight(); resizeEvalGraph(); });
+          $(window).on('resize', function(){
+            board.resize();
+            adjustAnalysisHeight();
+            resizeEvalGraph();
+            if (showBestMove && lastBestMove) {
+              drawBestMoveArrow(lastBestMove.substring(0,2), lastBestMove.substring(2,4));
+            }
+          });
           initEvalGraph();
         }
 
@@ -876,7 +942,14 @@ Before providing any output, you must perform a final check after generating the
 
         $('#next-btn').on('click', function(){ goToMove(currentMoveIndex + 1); });
         $('#prev-btn').on('click', function(){ goToMove(currentMoveIndex - 1); });
-        $('#flip-btn').on('click', function(){ if (board) board.flip(); });
+        $('#flip-btn').on('click', function(){
+          if (board) {
+            board.flip();
+            if (showBestMove && lastBestMove) {
+              drawBestMoveArrow(lastBestMove.substring(0,2), lastBestMove.substring(2,4));
+            }
+          }
+        });
         $('#toggle-eval-btn').on('click', function(){
           showBestMove = !showBestMove;
           if (showBestMove) {
@@ -888,7 +961,13 @@ Before providing any output, you must perform a final check after generating the
           }
         });
 
-        $(window).on('resize', function(){ adjustAnalysisHeight(); resizeEvalGraph(); });
+        $(window).on('resize', function(){
+          adjustAnalysisHeight();
+          resizeEvalGraph();
+          if (showBestMove && lastBestMove) {
+            drawBestMoveArrow(lastBestMove.substring(0,2), lastBestMove.substring(2,4));
+          }
+        });
         $(document).on('keydown', function(e){ if (!$('#review-section').is(':visible')) return; if (e.key==='ArrowRight') goToMove(currentMoveIndex + 1); if (e.key==='ArrowLeft') goToMove(currentMoveIndex - 1); });
       });
     </script>


### PR DESCRIPTION
## Summary
- Draw an arrow on the board to show Stockfish's recommended move
- Allow `getScore` to combine depth and movetime for deeper analysis
- Redraw arrows on board flips and window resizes for dynamic updates

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7580a41a88333b35dc3b40ad3c368