### PR TITLE
Improve comment parsing and arrow style

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,29 +605,29 @@ Before providing any output, you must perform a final check after generating the
           const toEl = document.querySelector('#board .square-' + to);
           if (!fromEl || !toEl) return;
           const fromRect = fromEl.getBoundingClientRect();
-          const toRect = toEl.getBoundingClientRect();
-          const fx = fromRect.left + fromRect.width / 2 - boardRect.left;
-          const fy = fromRect.top + fromRect.height / 2 - boardRect.top;
-          const tx = toRect.left + toRect.width / 2 - boardRect.left;
-          const ty = toRect.top + toRect.height / 2 - boardRect.top;
-          const lineWidth = arrowCanvas.width / 35;
-          const headlen = arrowCanvas.width / 20;
-          arrowCtx.strokeStyle = '#fbbf24';
-          arrowCtx.fillStyle = '#fbbf24';
-          arrowCtx.lineWidth = lineWidth;
-          arrowCtx.lineCap = 'round';
-          arrowCtx.beginPath();
-          arrowCtx.moveTo(fx, fy);
-          arrowCtx.lineTo(tx, ty);
-          arrowCtx.stroke();
-          const angle = Math.atan2(ty - fy, tx - fx);
-          arrowCtx.beginPath();
-          arrowCtx.moveTo(tx, ty);
-          arrowCtx.lineTo(tx - headlen * Math.cos(angle - Math.PI / 6), ty - headlen * Math.sin(angle - Math.PI / 6));
-          arrowCtx.lineTo(tx - headlen * Math.cos(angle + Math.PI / 6), ty - headlen * Math.sin(angle + Math.PI / 6));
-          arrowCtx.closePath();
-          arrowCtx.fill();
-        }
+            const toRect = toEl.getBoundingClientRect();
+            const fx = fromRect.left + fromRect.width / 2 - boardRect.left;
+            const fy = fromRect.top + fromRect.height / 2 - boardRect.top;
+            const tx = toRect.left + toRect.width / 2 - boardRect.left;
+            const ty = toRect.top + toRect.height / 2 - boardRect.top;
+            const lineWidth = arrowCanvas.width / 35;
+            const headlen = arrowCanvas.width / 15;
+            arrowCtx.strokeStyle = '#9ca3af';
+            arrowCtx.fillStyle = '#9ca3af';
+            arrowCtx.lineWidth = lineWidth;
+            arrowCtx.lineCap = 'square';
+            arrowCtx.lineJoin = 'miter';
+            arrowCtx.beginPath();
+            arrowCtx.moveTo(fx, fy);
+            arrowCtx.lineTo(tx, ty);
+            arrowCtx.stroke();
+            const angle = Math.atan2(ty - fy, tx - fx);
+            arrowCtx.beginPath();
+            arrowCtx.moveTo(tx, ty);
+            arrowCtx.lineTo(tx - headlen * Math.cos(angle - Math.PI / 6), ty - headlen * Math.sin(angle - Math.PI / 6));
+            arrowCtx.lineTo(tx - headlen * Math.cos(angle + Math.PI / 6), ty - headlen * Math.sin(angle + Math.PI / 6));
+            arrowCtx.closePath();
+            arrowCtx.fill();
 
         function showBestMoveForCurrentPosition() {
           if (!showBestMove || !engineReady) return;
@@ -681,6 +681,10 @@ Before providing any output, you must perform a final check after generating the
         const gameMoves = game.history({ verbose: true }); let cursor = 0;
         movesWithAnalysis = gameMoves.map(m => {
           let analysis = null;
+          if (cursor < parsed.moves.length && parsed.moves[cursor].san !== m.san) {
+            const found = parsed.moves.findIndex((pm, idx) => idx >= cursor && pm.san === m.san);
+            if (found !== -1) cursor = found;
+          }
           if (cursor < parsed.moves.length && parsed.moves[cursor].san === m.san) analysis = parsed.moves[cursor++];
           let prob = null;
           if (analysis) {


### PR DESCRIPTION
## Summary
- Preserve move evaluations and comments even in long games by resynchronizing parsed moves with PGN history
- Restyle best-move arrow with gray color, larger head, and square lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c4e553c8333a486483481f614d6