### PR TITLE
Fix missing brace in drawBestMoveArrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,6 +628,7 @@ Before providing any output, you must perform a final check after generating the
             arrowCtx.lineTo(tx - headlen * Math.cos(angle + Math.PI / 6), ty - headlen * Math.sin(angle + Math.PI / 6));
             arrowCtx.closePath();
             arrowCtx.fill();
+        }
 
         function showBestMoveForCurrentPosition() {
           if (!showBestMove || !engineReady) return;


### PR DESCRIPTION
## Summary
- fix unclosed drawBestMoveArrow function by adding the missing closing brace

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c76215da788333885dd717515412c5