### PR TITLE
Use yellow arrow with separated head for best move

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,16 +612,19 @@ Before providing any output, you must perform a final check after generating the
             const ty = toRect.top + toRect.height / 2 - boardRect.top;
             const lineWidth = arrowCanvas.width / 35;
             const headlen = arrowCanvas.width / 10;
-            arrowCtx.strokeStyle = 'rgba(156, 163, 175, 0.5)';
-            arrowCtx.fillStyle = 'rgba(156, 163, 175, 0.5)';
+            arrowCtx.strokeStyle = 'rgba(255, 255, 0, 0.5)';
+            arrowCtx.fillStyle = 'rgba(255, 255, 0, 0.5)';
             arrowCtx.lineWidth = lineWidth;
             arrowCtx.lineCap = 'butt';
             arrowCtx.lineJoin = 'miter';
+            const angle = Math.atan2(ty - fy, tx - fx);
             arrowCtx.beginPath();
             arrowCtx.moveTo(fx, fy);
-            arrowCtx.lineTo(tx, ty);
+            arrowCtx.lineTo(
+                tx - headlen * Math.cos(angle),
+                ty - headlen * Math.sin(angle)
+            );
             arrowCtx.stroke();
-            const angle = Math.atan2(ty - fy, tx - fx);
             arrowCtx.beginPath();
             arrowCtx.moveTo(tx, ty);
             arrowCtx.lineTo(tx - headlen * Math.cos(angle - Math.PI / 6), ty - headlen * Math.sin(angle - Math.PI / 6));


### PR DESCRIPTION
## Summary
- Draw best-move arrow in semi-transparent yellow
- Stop arrow shaft before triangular head while keeping arrow tip at destination

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c767ee6f548333b4f5517a7731c6ed