### PR TITLE
Hide depth from best move evaluation pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,10 +674,9 @@ Before providing any output, you must perform a final check after generating the
           const display = $('#best-eval-display');
           if (!display.length) return;
           const evalText = formatBestEval(info);
-          const depthText = info.depth != null ? ' · d' + info.depth : '';
           const sanMove = uciToSan(info.move);
           const moveText = sanMove ? ' · ' + sanMove : '';
-          display.removeClass('hidden').text(evalText + depthText + moveText);
+          display.removeClass('hidden').text(evalText + moveText);
         }
 
         function formatBestEval(info) {


### PR DESCRIPTION
## Summary
- remove the live best-move pill's depth readout so only the evaluation and move remain visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c88b1b413c8333a45af719cf0e46ea