### PR TITLE
Remove text labels from navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,8 +123,8 @@
           <div class="w-full max-w-xl mx-auto">
             <div id="board" class="chessboard-container"></div>
             <div id="controls" class="mt-3 flex items-center justify-center gap-2 w-full">
-              <button id="prev-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">‹ Prev</button>
-              <button id="next-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Next ›</button>
+              <button id="prev-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move">‹</button>
+              <button id="next-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move">›</button>
               <button id="flip-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Flip</button>
               <button id="toggle-eval-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Best</button>
               <span id="best-eval-display" class="hidden text-sm font-mono text-yellow-300 px-2 py-1 border border-yellow-400/40 rounded-lg bg-[#0b0e15]"></span>


### PR DESCRIPTION
## Summary
- update the previous and next navigation buttons to show only their arrow symbols
- add accessible aria-label text to preserve clarity for screen readers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c88be3ca8c8333ad515e9c2ccac874