### PR TITLE
Remove separator dot from best move eval pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@ Before providing any output, you must perform a final check after generating the
           if (!display.length) return;
           const evalText = formatBestEval(info);
           const sanMove = uciToSan(info.move);
-          const moveText = sanMove ? ' · ' + sanMove : '';
+          const moveText = sanMove ? ' ' + sanMove : '';
           display.removeClass('hidden').text(evalText + moveText);
         }
 


### PR DESCRIPTION
## Summary
- remove the dot separator from the live evaluation pill so only the eval and move text are shown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c88f5c0d1883339b85f246f7754e57