### PR TITLE
Allow review parser to read brace-only move format

### DIFF
--- a/index.html
+++ b/index.html
@@ -961,7 +961,7 @@ Before providing any output, you must perform a final check after generating the
       // Parse analysis lines with optional {eval} and final Summary:
       function parseAnalysis(text) {
         const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = ''; let inSummary = false;
-        const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)\s*[-–—]\s*(\{[^}]+\})?\s*([A-Za-z!?\s]+)\s*:\s*(.*)/;
+        const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)(?:\s*[-–—]\s*)?(?:\s*(\{[^}]+\}))?\s*([A-Za-z0-9!?\'"()\-\s]+?)\s*:\s*(.*)/;
         const criticalMomentRegex = /^Critical Moment:\s*(.*)/i;
         const summaryHeaderRegex = /^\s*\*\*(Strengths|Recurring Mistakes|Top 3 Takeaways)\*\*/i;
         // Allow leading whitespace before "Summary:" to handle AI outputs


### PR DESCRIPTION
## Summary
- expand the final analysis parser to accept move comments that omit a dash before the evaluation token

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c96a605e788333af8bc979bb4c8eab