### PR TITLE
Enable best move analysis during free play

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,7 @@ Final Verification Protocol (most important instruction: HIGHEST PRIORITY): Befo
           if (move) {
             board.position(game.fen());
             clearSelected();
+            handleFreePlayAfterMove();
           } else {
             clearSelected();
             if (game.get(square)) {
@@ -817,6 +818,15 @@ Final Verification Protocol (most important instruction: HIGHEST PRIORITY): Befo
               engineWorker.postMessage('go infinite');
             }
           }, 0);
+        }
+
+        function handleFreePlayAfterMove() {
+          $('.move-item').removeClass('highlight');
+          renderEvalGraph(-1);
+          clearBestMoveHighlight();
+          if (showBestMove) {
+            showBestMoveForCurrentPosition();
+          }
         }
 
       $('#copy-stockfish-btn').on('click', function () {


### PR DESCRIPTION
## Summary
- trigger free-play mode handling after manual moves so review highlights and graphs reset
- restart best-move evaluation for the current free-play position so the overlay always reflects the live board

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c99fbae4908333b8ab76e731813f96