### PR TITLE
Fix best move overlay piece detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,8 @@ Self-audit checklist before output submission:
           const sanMove = uciToSan(moveStr, bestMoveFen);
           if (!sanMove) return;
           const fromSquareEl = $('#board .square-' + from);
-          if (!fromSquareEl.length || fromSquareEl.find('.piece').length === 0) {
+          const fromPieceEl = fromSquareEl.find('[data-piece]');
+          if (!fromSquareEl.length || fromPieceEl.length === 0) {
             const attempts = info.retryCount || 0;
             if (attempts < 5) {
               info.retryCount = attempts + 1;


### PR DESCRIPTION
## Summary
- ensure the best-move overlay waits for piece elements by checking for chessboard.js data-piece markers
- keep the retry loop but allow the evaluation display to populate once a piece is present

## Testing
- manual browser verification of the Best button to confirm the evaluation text updates

------
https://chatgpt.com/codex/tasks/task_e_68ca6c881078833396e9271a550d98e8