### PR TITLE
Align board controls to the left

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
           <!-- Board -->
           <div class="w-full max-w-xl mx-auto">
             <div id="board" class="chessboard-container"></div>
-            <div id="controls" class="mt-3 flex items-center justify-center gap-2 w-full">
+            <div id="controls" class="mt-3 flex items-center justify-start gap-2 w-full">
               <button id="prev-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move">‹</button>
               <button id="next-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move">›</button>
               <button id="flip-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Flip</button>


### PR DESCRIPTION
## Summary
- left-align the board navigation controls so the arrow buttons, Flip, Best, and evaluation pill sit at the start of the row

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caae8c44cc83338db6f6bd3bbf0f95