### PR TITLE
Improve navigation buttons and add clear control

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
     </div>
     <div class="flex flex-col sm:flex-row gap-2">
       <button id="back-to-step1-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-secondary">
-        Back to Step 1
+        Back
       </button>
       <button id="goto-step3-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary">
         Continue to Final Step
@@ -113,12 +113,15 @@
     <h2 class="text-xl sm:text-2xl font-bold text-center">Step 3: Paste Your Final AI Review</h2>
     <p class="text-center text-gray-400">Paste the full text from the AI (PGN + comments) or just comments like <em>e4 - {3} Good: ...</em>. The braces should contain the mover's evaluation delta in percentage points—positive values mean the mover improved their position, negative values mean they worsened it. Include the final line starting with <strong>Summary:</strong>.</p>
     <div>
-      <label for="final-analysis-input" class="block mb-2 font-semibold text-gray-300">Paste complete analysis here</label>
+      <div class="flex items-center justify-between mb-2 gap-2">
+        <label for="final-analysis-input" class="block font-semibold text-gray-300">Paste complete analysis here</label>
+        <button id="clear-final-analysis-btn" type="button" class="py-1 px-2 text-sm font-semibold text-white rounded-md btn-secondary whitespace-nowrap">Clear</button>
+      </div>
       <textarea id="final-analysis-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="e4 - {3} Good: A classical opening move...\n...\nSummary: Black won after a decisive kingside attack."></textarea>
     </div>
     <div class="flex flex-col sm:flex-row gap-2">
       <button id="back-to-step2-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-secondary">
-        Back to Step 2
+        Back
       </button>
       <button id="generate-review-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary">
         Generate Interactive Review
@@ -725,6 +728,10 @@ Self-audit checklist before output submission:
       $('#goto-step2-btn').on('click', function(){ switchStep(2); });
       $('#back-to-step1-btn').on('click', function(){ switchStep(1); });
       $('#back-to-step2-btn').on('click', function(){ switchStep(2); });
+      $('#clear-final-analysis-btn').on('click', function(){
+        $('#final-analysis-input').val('').trigger('input');
+        $('#final-analysis-input').focus();
+      });
 
       $('#analyze-pgn-btn').on('click', async function () {
         const pgnRaw = $('#pgn-input').val().trim(); if (!pgnRaw) { showError('Please paste a PGN.'); return; }


### PR DESCRIPTION
## Summary
- rename the step navigation buttons so they simply read "Back" for consistency
- add a Clear control beside the final analysis textarea and wire it up to reset and focus the field

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cac4c63a208333b4b8b61c09ee6dda