### PR TITLE
Add clear control beside final analysis textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,11 @@
     <h2 class="text-xl sm:text-2xl font-bold text-center">Step 3: Paste Your Final AI Review</h2>
     <p class="text-center text-gray-400">Paste the full text from the AI (PGN + comments) or just comments like <em>e4 - {3} Good: ...</em>. The braces should contain the mover's evaluation delta in percentage points—positive values mean the mover improved their position, negative values mean they worsened it. Include the final line starting with <strong>Summary:</strong>.</p>
     <div>
-      <div class="flex items-center justify-between mb-2 gap-2">
-        <label for="final-analysis-input" class="block font-semibold text-gray-300">Paste complete analysis here</label>
-        <button id="clear-final-analysis-btn" type="button" class="py-1 px-2 text-sm font-semibold text-white rounded-md btn-secondary whitespace-nowrap">Clear</button>
+      <label for="final-analysis-input" class="block font-semibold text-gray-300 mb-2">Paste complete analysis here</label>
+      <div class="flex flex-col sm:flex-row sm:items-start gap-2">
+        <textarea id="final-analysis-input" rows="6" class="flex-1 w-full p-3 rounded-lg form-input" placeholder="e4 - {3} Good: A classical opening move...\n...\nSummary: Black won after a decisive kingside attack."></textarea>
+        <button id="clear-final-analysis-btn" type="button" class="sm:self-start py-2 px-3 text-sm font-semibold text-white rounded-md btn-secondary whitespace-nowrap">Clear</button>
       </div>
-      <textarea id="final-analysis-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="e4 - {3} Good: A classical opening move...\n...\nSummary: Black won after a decisive kingside attack."></textarea>
     </div>
     <div class="flex flex-col sm:flex-row gap-2">
       <button id="back-to-step2-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-secondary">
@@ -729,8 +729,8 @@ Self-audit checklist before output submission:
       $('#back-to-step1-btn').on('click', function(){ switchStep(1); });
       $('#back-to-step2-btn').on('click', function(){ switchStep(2); });
       $('#clear-final-analysis-btn').on('click', function(){
-        $('#final-analysis-input').val('').trigger('input');
-        $('#final-analysis-input').focus();
+        const finalAnalysisInput = $('#final-analysis-input');
+        finalAnalysisInput.val('').trigger('input').focus();
       });
 
       $('#analyze-pgn-btn').on('click', async function () {


### PR DESCRIPTION
## Summary
- place the final analysis textarea and its Clear button in a shared flex layout so the control sits beside the field
- streamline the Clear handler to reuse a cached reference when clearing, triggering persistence updates, and focusing the textarea

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cac71508cc83338b03ee1e0ed487c9