### PR TITLE
Add clear button for PGN input

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,10 @@
     <p class="text-center text-gray-400">Paste your game's PGN below. The engine will run in your browser to add move evaluations.</p>
     <div>
       <label for="pgn-input" class="block mb-2 font-semibold text-gray-300">Paste PGN here</label>
-      <textarea id="pgn-input" rows="6" class="w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
+      <div class="flex flex-col sm:flex-row sm:items-start gap-2">
+        <textarea id="pgn-input" rows="6" class="flex-1 w-full p-3 rounded-lg form-input" placeholder="[Event &quot;...&quot;]..."></textarea>
+        <button id="clear-pgn-btn" type="button" class="sm:self-start py-2 px-3 text-sm font-semibold text-white rounded-md btn-secondary whitespace-nowrap">Clear</button>
+      </div>
     </div>
     <div class="flex justify-center gap-2 text-sm">
       <div class="flex flex-col items-center">
@@ -728,6 +731,10 @@ Self-audit checklist before output submission:
       $('#goto-step2-btn').on('click', function(){ switchStep(2); });
       $('#back-to-step1-btn').on('click', function(){ switchStep(1); });
       $('#back-to-step2-btn').on('click', function(){ switchStep(2); });
+      $('#clear-pgn-btn').on('click', function(){
+        const pgnInput = $('#pgn-input');
+        pgnInput.val('').trigger('input').focus();
+      });
       $('#clear-final-analysis-btn').on('click', function(){
         const finalAnalysisInput = $('#final-analysis-input');
         finalAnalysisInput.val('').trigger('input').focus();


### PR DESCRIPTION
## Summary
- add a Clear button next to the PGN input on the first step layout for easier resets
- wire the Clear control to empty and refocus the PGN textarea while preserving state handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae69116f48333b0406bfec88e783a