### PR TITLE
Use long arrows for navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     .step-indicator.active { background-color: #3b82f6; }
     .step-indicator:focus-visible { outline: 2px solid #60a5fa; outline-offset: 2px; }
     #board .square-55d63.selected { background-color: rgba(251, 191, 36, 0.5); }
+    #prev-btn, #next-btn { font-size: calc(1rem + 4pt); }
   </style>
 </head>
 <body class="min-h-screen flex flex-col p-3 sm:p-4">
@@ -145,8 +146,8 @@
           <div class="w-full max-w-xl mx-auto">
             <div id="board" class="chessboard-container"></div>
             <div id="controls" class="mt-3 flex items-center justify-start gap-2 w-full">
-              <button id="prev-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move">⟵</button>
-              <button id="next-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move">⟶</button>
+              <button id="prev-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move">⟸</button>
+              <button id="next-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move">⟹</button>
               <button id="flip-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Flip</button>
               <button id="toggle-eval-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Best</button>
               <span id="best-eval-display" class="hidden text-sm font-mono text-yellow-300 px-2 py-1 border border-yellow-400/40 rounded-lg bg-[#0b0e15]"></span>


### PR DESCRIPTION
## Summary
- replace the previous and next navigation button labels with long arrow glyphs for clearer direction cues
- enlarge the navigation arrow font size by four points to improve their visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc2a564a908333b4f5895f52f48cd0