### PR TITLE
Add final step navigation and update review controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,9 @@
 
   <!-- Final Review Section (mobile-optimized) -->
   <main id="review-section" class="hidden flex-1 max-w-5xl w-full mx-auto">
+    <div class="w-full flex justify-start mb-3">
+      <button id="back-to-step3-btn" type="button" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Back to Step 3</button>
+    </div>
     <div class="w-full grid grid-cols-1 lg:grid-cols-2 gap-3">
       <!-- Column A: Board + evaluation graph (sticky) -->
       <div class="lg:col-span-1">
@@ -145,12 +148,12 @@
           <!-- Board -->
           <div class="w-full max-w-xl mx-auto">
             <div id="board" class="chessboard-container"></div>
-            <div id="controls" class="mt-3 flex items-center justify-start gap-2 w-full">
-              <button id="prev-btn" class="px-2 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move"> ᐊ </button>
-              <button id="next-btn" class="px-2 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move"> ᐅ </button>
-              <button id="flip-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Flip</button>
-              <button id="toggle-eval-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Best</button>
+            <div id="controls" class="mt-3 flex items-center justify-end gap-2 w-full">
               <span id="best-eval-display" class="hidden text-sm font-mono text-yellow-300 px-2 py-1 border border-yellow-400/40 rounded-lg bg-[#0b0e15]"></span>
+              <button id="toggle-eval-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Best</button>
+              <button id="flip-btn" class="px-4 py-2 text-white font-semibold rounded-lg btn-secondary">Flip</button>
+              <button id="prev-btn" class="px-3 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Previous move">Prev</button>
+              <button id="next-btn" class="px-3 py-2 text-white font-semibold rounded-lg btn-secondary" aria-label="Next move">Next</button>
             </div>
           </div>
         </div>
@@ -732,6 +735,7 @@ Self-audit checklist before output submission:
       $('#goto-step2-btn').on('click', function(){ switchStep(2); });
       $('#back-to-step1-btn').on('click', function(){ switchStep(1); });
       $('#back-to-step2-btn').on('click', function(){ switchStep(2); });
+      $('#back-to-step3-btn').on('click', function(){ switchStep(3); });
       $('#clear-pgn-btn').on('click', function(){
         const pgnInput = $('#pgn-input');
         pgnInput.val('').trigger('input').focus();


### PR DESCRIPTION
## Summary
- add a Back to Step 3 button on the final review screen to restore step navigation
- reorder the review controls so the evaluation pill precedes Best, Flip, Prev, and Next
- replace the arrow icons with Prev/Next labels and right-align the board controls for clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda74b334c83338099f738df79ed5e