### PR TITLE
Adjust best move pill label during analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1014,8 +1014,7 @@ Self-audit checklist before output submission:
         }
 
         function showBestMoveAnalyzingDisplay() {
-          const baseLabel = defaultBestButtonLabel || 'Best';
-          setBestButtonState(baseLabel + ' • Analyzing…', true);
+          setBestButtonState('Analyzing…', true);
         }
 
         function hideBestMoveEvalDisplay() {
@@ -1096,8 +1095,7 @@ Self-audit checklist before output submission:
           if (!toggleBestBtn.length) return;
           const evalText = formatBestEval(info);
           const moveText = sanMove ? ' ' + sanMove : '';
-          const baseLabel = defaultBestButtonLabel || 'Best';
-          const combined = evalText ? `${baseLabel} • ${evalText}${moveText}` : baseLabel;
+          const combined = evalText ? `${evalText}${moveText}` : 'Analyzing…';
           setBestButtonState(combined.trim(), true);
         }
 


### PR DESCRIPTION
## Summary
- update the best-move toggle label so the static "Best" text is removed once analysis begins, leaving only the status or evaluation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cde2ca94848333b3b072cf9e42b5ef