### PR TITLE
Ensure section buttons display in a single row

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
         <input id="hash-input" type="number" min="256" value="469" class="w-16 p-1 rounded form-input text-center"/>
       </div>
     </div>
-    <div class="flex flex-col sm:flex-row gap-2">
+    <div class="grid grid-cols-2 gap-2">
       <button id="analyze-pgn-btn" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-primary" disabled>
         Loading Engine...
       </button>
@@ -103,7 +103,7 @@
       <textarea id="stockfish-output" rows="7" class="w-full p-3 rounded-lg form-input font-mono text-sm" readonly></textarea>
       <button id="copy-stockfish-btn" class="w-full mt-2 py-2 px-4 font-semibold text-white rounded-lg btn-secondary">Copy to Clipboard</button>
     </div>
-    <div class="flex flex-col sm:flex-row gap-2">
+    <div class="grid grid-cols-2 gap-2">
       <button id="back-to-step1-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-secondary">
         Back
       </button>
@@ -123,7 +123,7 @@
         <button id="clear-final-analysis-btn" type="button" class="sm:self-start py-2 px-3 text-sm font-semibold text-white rounded-md btn-secondary whitespace-nowrap">Clear</button>
       </div>
     </div>
-    <div class="flex flex-col sm:flex-row gap-2">
+    <div class="grid grid-cols-2 gap-2">
       <button id="back-to-step2-btn" type="button" class="w-full py-3 px-6 text-lg font-semibold text-white rounded-lg btn-secondary">
         Back
       </button>


### PR DESCRIPTION
## Summary
- update the step action button containers to use a two-column grid so that paired buttons stay on one row across breakpoints

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0618688c88333aada31f70c8ec33c