### PR TITLE
Add featured move summary to review

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     .move-item { transition: background-color 0.2s ease-in-out; border-radius: 0.5rem; }
     .move-item.highlight { background-color: #243249; }
     .move-item:hover { background-color: #1c273a; }
+    .move-item.featured { border: 1px solid rgba(250, 204, 21, 0.35); background-color: rgba(250, 204, 21, 0.06); }
+    .move-item.featured:hover { background-color: rgba(250, 204, 21, 0.12); }
+    .move-item.featured.highlight { background-color: #243249; }
     #move-analysis-scroll::-webkit-scrollbar { width: 8px; }
     #move-analysis-scroll::-webkit-scrollbar-track { background: #1a1f2a; }
     #move-analysis-scroll::-webkit-scrollbar-thumb { background-color: #4b5563; border-radius: 10px; border: 2px solid #1a1f2a; }
@@ -164,6 +167,7 @@
           <div id="move-analysis-scroll" class="overflow-y-auto">
             <!-- One-line summary appears here (from "Summary:") -->
             <div id="game-summary" class="hidden mb-3 p-2 rounded bg-[#0b0e15] text-sm text-gray-200"></div>
+            <div id="featured-move" class="hidden mb-3"></div>
             <div id="move-analysis-container" class="space-y-1"></div>
           </div>
         </div>
@@ -419,6 +423,8 @@ Self-audit checklist before output submission:
       let probSeries = []; // WHITE win probability per ply (0..1)
       let evalCanvas = null;
       let evalCtx = null;
+      let featuredMoveData = null;
+      let featuredMoveIndex = -1;
 
       const classificationStyles = {
         brilliant: 'text-cyan-300',
@@ -432,10 +438,13 @@ Self-audit checklist before output submission:
         misclick: 'text-fuchsia-500',
         default: ''
       };
-      function getStyleForClassification(c) {
-        return classificationStyles[(c || '')
+      function normalizeClassificationKey(c) {
+        return (c || '')
           .toLowerCase()
-          .replace(/[\s!?]/g, '')] || classificationStyles['default'];
+          .replace(/[\s!?]/g, '');
+      }
+      function getStyleForClassification(c) {
+        return classificationStyles[normalizeClassificationKey(c)] || classificationStyles['default'];
       }
       let selectedSquare = null;
       function clearSelected() {
@@ -1381,6 +1390,17 @@ Self-audit checklist before output submission:
           $('#game-summary').addClass('hidden').html('');
         }
 
+        featuredMoveData = parsed.featuredMove || null;
+        featuredMoveIndex = -1;
+        if (featuredMoveData) {
+          const idx = findFeaturedMoveIndex(movesWithAnalysis, featuredMoveData);
+          if (idx >= 0) {
+            featuredMoveIndex = idx;
+            movesWithAnalysis[idx].isFeatured = true;
+          }
+        }
+        renderFeaturedMoveSummary();
+
         if (!board) {
           board = Chessboard('board', {
             position: 'start',
@@ -1428,16 +1448,39 @@ Self-audit checklist before output submission:
 
       // Parse analysis lines with optional {eval} and final Summary:
       function parseAnalysis(text) {
-        const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = ''; let inSummary = false;
+        const lines = text.split('\n'); const parsedMoves = []; const criticalMoments = {}; const summaries = {}; let currentSummary = null; let lastSan = null; let summaryLine = ''; let inSummary = false; let featuredMove = null;
         const moveRegex = /^(?:\d+\.{1,3}\s*)?(\S+)(?:\s*[-–—]\s*)?(?:\s*(\{[^}]+\}))?\s*([A-Za-z0-9!?\'"()\-\s]+?)\s*:\s*(.*)/;
         const criticalMomentRegex = /^Critical Moment:\s*(.*)/i;
         const summaryHeaderRegex = /^\s*\*\*(Strengths|Recurring Mistakes|Top 3 Takeaways)\*\*/i;
         // Allow leading whitespace before "Summary:" to handle AI outputs
         // that may indent or space the final summary line.
         const summaryLineRegex = /^\s*Summary[^:]*:\s*(.*)/i;
+        const moveOfGameRegex = /^\s*Move of the game:\s*([^\s]+)(?:\s*[-–—]\s*(\{[^}]+\}))?\s*([A-Za-z0-9!?\'"()\-\s]+?):\s*(.*)$/i;
+
+        function assignFeatured(match) {
+          if (!match) return false;
+          if (featuredMove) return true;
+          const san = match[1];
+          if (!san) return true;
+          const evaluation = (match[2] || '').trim() || null;
+          const classification = (match[3] || '').trim();
+          const justification = (match[4] || '').trim();
+          const evalInfo = parseEvaluationToken(evaluation);
+          featuredMove = { san, evaluation, classification, text: justification, ...evalInfo };
+          return true;
+        }
+
         lines.forEach(line => {
-          if (inSummary) { if (line.trim()) summaryLine += ' ' + line.trim(); return; }
-          const sl = line.match(summaryLineRegex); if (sl) { summaryLine = sl[1].trim(); inSummary = true; return; }
+          const trimmed = line.trim();
+          if (inSummary) {
+            if (!trimmed) return;
+            if (assignFeatured(line.match(moveOfGameRegex))) { inSummary = false; return; }
+            summaryLine += ' ' + trimmed;
+            return;
+          }
+          const sl = line.match(summaryLineRegex);
+          if (sl) { summaryLine = sl[1].trim(); inSummary = true; return; }
+          if (assignFeatured(line.match(moveOfGameRegex))) return;
           const m = line.match(moveRegex);
           if (m) {
             const san = m[1];
@@ -1450,9 +1493,9 @@ Self-audit checklist before output submission:
           }
           const cm = line.match(criticalMomentRegex); if (cm && lastSan) { criticalMoments[lastSan] = cm[1]; return; }
           const sh = line.match(summaryHeaderRegex); if (sh) { const key = sh[1].replace(/\s/g,''); summaries[key] = []; currentSummary = key; return; }
-          if (line.trim() && line.trim() !== '---' && currentSummary) summaries[currentSummary].push(line.trim());
+          if (trimmed && trimmed !== '---' && currentSummary) summaries[currentSummary].push(trimmed);
         });
-        return { moves: parsedMoves, criticalMoments, summaries, summary: summaryLine };
+        return { moves: parsedMoves, criticalMoments, summaries, summary: summaryLine, featuredMove };
       }
 
       // Convert evaluation string like "{+0.23}", "{-1.10}", "{#3}" (WHITE-relative already)
@@ -1497,52 +1540,131 @@ Self-audit checklist before output submission:
       }
 
       // ====== Rendering ======
+      function buildEvaluationSegments(mv) {
+        const segments = [];
+        if (!mv) return segments;
+        let mateDisplay = '';
+        if (mv.analysis && mv.analysis.kind === 'mate') {
+          const mateStr = mv.analysis.displayEvaluation || mv.displayEvaluation || mv.analysis.evaluation;
+          if (mateStr) {
+            mateDisplay = '<span class="font-mono text-xs text-yellow-300">' + mateStr + '</span>';
+            segments.push(mateDisplay);
+          }
+        }
+        const whiteProbSource = mv.prob != null ? mv.prob : (mv.analysis ? mv.analysis.prob : null);
+        if (!mateDisplay) {
+          const whiteProbHtml = formatWhiteWinProbDisplay(whiteProbSource);
+          if (whiteProbHtml) segments.push(whiteProbHtml);
+        }
+        const moverDeltaSource = mv.delta != null
+          ? mv.delta
+          : (mv.analysis && mv.analysis.delta != null ? mv.analysis.delta : null);
+        const moverDeltaHtml = formatMoverDeltaIndicator(moverDeltaSource);
+        if (moverDeltaHtml) segments.push(moverDeltaHtml);
+        if (!segments.length) {
+          let fallbackEval = mv.displayEvaluation;
+          if (!fallbackEval && mv.analysis && mv.analysis.displayEvaluation) fallbackEval = mv.analysis.displayEvaluation;
+          if (!fallbackEval && mv.analysis && mv.analysis.evaluation) fallbackEval = mv.analysis.evaluation;
+          if (!fallbackEval && mv.delta != null) fallbackEval = formatDeltaBraced(mv.delta);
+          if (fallbackEval) {
+            segments.push('<span class="font-mono text-xs text-gray-400">' + fallbackEval + '</span>');
+          }
+        }
+        return segments;
+      }
+
+      function normalizeEvaluationString(value) {
+        if (!value) return '';
+        return String(value).replace(/[{}\s]/g, '').toLowerCase();
+      }
+
+      function findFeaturedMoveIndex(list, featured) {
+        if (!featured || !Array.isArray(list) || !list.length) return -1;
+        const targetSan = (featured.san || '').trim();
+        if (!targetSan) return -1;
+        const targetClass = normalizeClassificationKey(featured.classification);
+        const targetEval = normalizeEvaluationString(featured.evaluation);
+        const matchesBase = mv => mv && mv.analysis && mv.san === targetSan;
+        const matchesClass = mv => matchesBase(mv) && (!targetClass || normalizeClassificationKey(mv.analysis.classification) === targetClass);
+        const matchesEval = mv => {
+          if (!targetEval || !matchesClass(mv)) return false;
+          const candidates = [
+            mv.analysis ? mv.analysis.evaluation : null,
+            mv.analysis ? mv.analysis.displayEvaluation : null,
+            mv.displayEvaluation
+          ];
+          return candidates.some(candidate => normalizeEvaluationString(candidate) === targetEval);
+        };
+        let idx = -1;
+        if (targetEval) idx = list.findIndex(matchesEval);
+        if (idx === -1 && targetClass) idx = list.findIndex(matchesClass);
+        if (idx === -1) idx = list.findIndex(matchesBase);
+        return idx;
+      }
+
+      function renderFeaturedMoveSummary() {
+        const container = $('#featured-move');
+        if (!container.length) return;
+        container.addClass('hidden').empty();
+        if (!featuredMoveData) return;
+        const idx = (featuredMoveIndex >= 0 && featuredMoveIndex < movesWithAnalysis.length) ? featuredMoveIndex : -1;
+        const move = idx >= 0 ? movesWithAnalysis[idx] : null;
+        const evaluationSegments = move ? buildEvaluationSegments(move) : [];
+        let evaluationHtml = '';
+        if (evaluationSegments.length) {
+          evaluationHtml = '<div class="flex items-center gap-2 text-xs sm:text-sm flex-wrap">' + evaluationSegments.join('') + '</div>';
+        } else if (featuredMoveData.evaluation) {
+          evaluationHtml = '<span class="font-mono text-xs text-yellow-300">' + featuredMoveData.evaluation + '</span>';
+        }
+        const classificationClass = getStyleForClassification(featuredMoveData.classification) || '';
+        const classificationHtml = featuredMoveData.classification
+          ? '<span class="ml-auto px-2 py-0.5 text-xs font-semibold uppercase tracking-wide rounded border border-yellow-500/40 bg-yellow-500/10 ' + classificationClass + '">' + featuredMoveData.classification + '</span>'
+          : '';
+        const justificationHtml = featuredMoveData.text
+          ? '<p class="mt-2 text-sm text-gray-200">' + formatText(featuredMoveData.text) + '</p>'
+          : '';
+        const isClickable = !!move;
+        const tag = isClickable ? 'button' : 'div';
+        const attrs = isClickable ? ' type="button" data-move-index="' + idx + '"' : '';
+        const baseClasses = 'w-full text-left p-3 sm:p-4 rounded-lg border border-yellow-500/40 bg-yellow-500/10' + (isClickable ? ' hover:bg-yellow-500/20 transition cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400/60' : ' opacity-90');
+        const headerParts = [
+          '<span class="text-xs uppercase tracking-wide text-yellow-300 font-semibold">Move of the game</span>',
+          '<span class="font-bold text-lg text-white">' + featuredMoveData.san + '</span>'
+        ];
+        if (evaluationHtml) headerParts.push(evaluationHtml);
+        if (classificationHtml) headerParts.push(classificationHtml);
+        const headerHtml = '<div class="flex items-center gap-3 flex-wrap sm:flex-nowrap">' + headerParts.join('') + '</div>';
+        container.removeClass('hidden').html('<' + tag + attrs + ' class="' + baseClasses + '">' + headerHtml + justificationHtml + '</' + tag + '>');
+        if (isClickable) {
+          container.find('button[data-move-index]').on('click', function(){
+            const targetIdx = Number($(this).data('move-index'));
+            if (!Number.isNaN(targetIdx)) goToMove(targetIdx);
+          });
+        }
+      }
+
       function renderMoveList() {
         const c = $('#move-analysis-container').empty();
         movesWithAnalysis.forEach((mv, i) => {
           const n = mv.color === 'w' ? (Math.floor(i / 2) + 1) + '.' : '';
-          let evalHtml = '';
-          const evaluationSegments = [];
-          let mateDisplay = '';
-          if (mv.analysis && mv.analysis.kind === 'mate') {
-            const mateStr = mv.analysis.displayEvaluation || mv.displayEvaluation || mv.analysis.evaluation;
-            if (mateStr) {
-              mateDisplay = '<span class="font-mono text-xs text-yellow-300">' + mateStr + '</span>';
-              evaluationSegments.push(mateDisplay);
-            }
-          }
-
-          const whiteProbSource = mv.prob != null ? mv.prob : (mv.analysis ? mv.analysis.prob : null);
-          const includeProb = !mateDisplay;
-          const whiteProbHtml = includeProb ? formatWhiteWinProbDisplay(whiteProbSource) : '';
-          if (whiteProbHtml) evaluationSegments.push(whiteProbHtml);
-
-          const moverDeltaSource = mv.delta != null
-            ? mv.delta
-            : (mv.analysis && mv.analysis.delta != null ? mv.analysis.delta : null);
-          const moverDeltaHtml = formatMoverDeltaIndicator(moverDeltaSource);
-          if (moverDeltaHtml) evaluationSegments.push(moverDeltaHtml);
-
-          if (!evaluationSegments.length) {
-            let fallbackEval = mv.displayEvaluation;
-            if (!fallbackEval && mv.analysis && mv.analysis.displayEvaluation) fallbackEval = mv.analysis.displayEvaluation;
-            if (!fallbackEval && mv.analysis && mv.analysis.evaluation) fallbackEval = mv.analysis.evaluation;
-            if (!fallbackEval && mv.delta != null) fallbackEval = formatDeltaBraced(mv.delta);
-            if (fallbackEval) {
-              evaluationSegments.push('<span class="font-mono text-xs text-gray-400">' + fallbackEval + '</span>');
-            }
-          }
-
-          if (evaluationSegments.length) {
-            evalHtml = '<div class="flex items-center gap-2 ml-2">' + evaluationSegments.join('') + '</div>';
-          }
+          const evalSegments = buildEvaluationSegments(mv);
+          const evalHtml = evalSegments.length ? '<div class="flex items-center gap-2 ml-2">' + evalSegments.join('') + '</div>' : '';
+          const moveClasses = ['move-item', 'p-2', 'cursor-pointer'];
+          if (mv.isFeatured) moveClasses.push('featured');
+          const classificationHtml = mv.analysis
+            ? '<span class="font-semibold text-sm ml-2 ' + getStyleForClassification(mv.analysis.classification) + '">' + mv.analysis.classification + '</span>'
+            : '';
+          const badgeHtml = mv.isFeatured
+            ? '<span class="ml-auto text-xs uppercase tracking-wide text-yellow-300 font-semibold">Move of the Game</span>'
+            : '';
           const html =
-            '<div class="move-item p-2 cursor-pointer" data-move-index="' + i + '">' +
+            '<div class="' + moveClasses.join(' ') + '" data-move-index="' + i + '">' +
               '<div class="flex items-baseline gap-3">' +
                 '<span class="text-gray-500 font-mono w-8 text-right">' + n + '</span>' +
                 '<span class="font-bold text-lg text-white">' + mv.san + '</span>' +
                 evalHtml +
-                (mv.analysis ? '<span class="font-semibold text-sm ml-2 ' + getStyleForClassification(mv.analysis.classification) + '">' + mv.analysis.classification + '</span>' : '') +
+                classificationHtml +
+                badgeHtml +
               '</div>' +
               (mv.analysis ? '<p class="pl-12 text-gray-300 text-sm">' + formatText(mv.analysis.text) + '</p>' : '') +
               (mv.criticalMoment ? '<p class="pl-12 mt-1 text-xs text-yellow-300 bg-yellow-900/40 p-2 rounded">' + formatText('**Critical Moment:** ' + mv.criticalMoment) + '</p>' : '') +


### PR DESCRIPTION
## Summary
- parse the "Move of the game" line from the final review and associate it with the correct move
- render a featured move card below the summary with navigation to that move and highlight it in the move list
- add helpers and styling to reuse evaluation formatting for both the card and move list

## Testing
- manual validation in browser (see attached screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68d2f43c7cf08333bcd1e70a8acf19bd