### PR TITLE
Capture featured move metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1395,8 +1395,11 @@ Self-audit checklist before output submission:
         if (featuredMoveData) {
           const idx = findFeaturedMoveIndex(movesWithAnalysis, featuredMoveData);
           if (idx >= 0) {
+            const meta = { ...featuredMoveData, index: idx };
+            featuredMoveData = meta;
             featuredMoveIndex = idx;
             movesWithAnalysis[idx].isFeatured = true;
+            movesWithAnalysis[idx].featuredMeta = meta;
           }
         }
         renderFeaturedMoveSummary();
@@ -1455,7 +1458,7 @@ Self-audit checklist before output submission:
         // Allow leading whitespace before "Summary:" to handle AI outputs
         // that may indent or space the final summary line.
         const summaryLineRegex = /^\s*Summary[^:]*:\s*(.*)/i;
-        const moveOfGameRegex = /^\s*Move of the game:\s*([^\s]+)(?:\s*[-–—]\s*(\{[^}]+\}))?\s*([A-Za-z0-9!?\'"()\-\s]+?):\s*(.*)$/i;
+        const moveOfGameRegex = /^\s*Move of the game:\s*([^\s]+)(?:\s*(?:[-–—]\s*)?(\{[^}]+\}))?\s*([A-Za-z0-9!?\'"()\-\s]+?):\s*(.*)$/i;
 
         function assignFeatured(match) {
           if (!match) return false;
@@ -1607,7 +1610,10 @@ Self-audit checklist before output submission:
         if (!container.length) return;
         container.addClass('hidden').empty();
         if (!featuredMoveData) return;
-        const idx = (featuredMoveIndex >= 0 && featuredMoveIndex < movesWithAnalysis.length) ? featuredMoveIndex : -1;
+        const idxFromData = typeof featuredMoveData.index === 'number' ? featuredMoveData.index : -1;
+        const idx = (idxFromData >= 0 && idxFromData < movesWithAnalysis.length)
+          ? idxFromData
+          : ((featuredMoveIndex >= 0 && featuredMoveIndex < movesWithAnalysis.length) ? featuredMoveIndex : -1);
         const move = idx >= 0 ? movesWithAnalysis[idx] : null;
         const evaluationSegments = move ? buildEvaluationSegments(move) : [];
         let evaluationHtml = '';


### PR DESCRIPTION
## Summary
- persist the parsed "Move of the game" metadata on the associated move so it can be reused during rendering
- capture featured-move evaluation tokens whether or not a dash separates them from the SAN
- reference the stored featured-move index when building the summary card

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2ff24399c8333901e21bb3bf891e1