### PR TITLE
Fix Stockfish worker URL resolution for more environments

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,18 +231,15 @@
       function resolveWorkerUrl(path) {
         if (!path) return path;
         try {
-          const { origin, pathname } = window.location;
-          let basePath = pathname || '/';
-          if (!basePath.endsWith('/')) {
-            const lastSlash = basePath.lastIndexOf('/');
-            const lastSegment = basePath.slice(lastSlash + 1);
-            const directoryPath = (lastSegment && lastSegment.includes('.'))
-              ? basePath.slice(0, lastSlash + 1)
-              : `${basePath}/`;
-            basePath = directoryPath || '/';
+          const normalized = String(path);
+          if (/^(?:[a-z]+:)?\/\//i.test(normalized) || normalized.startsWith('blob:') || normalized.startsWith('data:')) {
+            return normalized;
           }
-          const baseUrl = origin + basePath;
-          return new URL(path, baseUrl).toString();
+          const baseHref = (typeof window !== 'undefined' && window.location && window.location.href)
+            ? window.location.href
+            : '';
+          if (!baseHref) return normalized;
+          return new URL(normalized, baseHref).toString();
         } catch (err) {
           console.warn('Falling back to raw worker path due to resolution error:', err);
           return path;


### PR DESCRIPTION
## Summary
- update the Stockfish worker URL resolver to handle blob/data URLs and fall back to window.location.href for relative paths
- improve resilience when loading the engine from file-based or subdirectory deployments

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5a825550883339d87ae75590cfef8