### PR TITLE
Fix engine cache busting

### DIFF
--- a/engine/stockfish-nnue-16-single.js
+++ b/engine/stockfish-nnue-16-single.js
@@ -1,6 +1,16 @@
 var Module = {
-  locateFile: () =>
-    new URL('stockfish-nnue-16-single.wasm', self.location.href).toString(),
+  locateFile: (path) => {
+    try {
+      var baseUrl = new URL(self.location.href);
+      var target = new URL(path || '', baseUrl);
+      if (baseUrl.search) {
+        target.search = baseUrl.search;
+      }
+      return target.toString();
+    } catch (err) {
+      return new URL(path || 'stockfish-nnue-16-single.wasm', self.location.href).toString();
+    }
+  },
 };
 /*!
  * Stockfish.js 16 (c) 2023, Chess.com, LLC

--- a/index.html
+++ b/index.html
@@ -247,7 +247,8 @@
       $('#player-name-input').on('input change', function () { refreshStockfishOutput(); });
 
       // ====== Stockfish (same-origin Worker) ======
-      const LOCAL_ENGINE = 'engine/stockfish-nnue-16-single.js';
+      const ENGINE_BUNDLE_VERSION = '20240609';
+      const LOCAL_ENGINE = `engine/stockfish-nnue-16-single.js?v=${ENGINE_BUNDLE_VERSION}`;
       function resolveWorkerUrl(path) {
         if (!path) return path;
         try {


### PR DESCRIPTION
## Summary
- add a cache-busting version string to the Stockfish worker URL so updates no longer require a manual cache clear
- propagate the version to the WASM loader so the matching binary is fetched when the worker updates

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68d78828c5dc8333947c2cc6c7e81f66