### PR TITLE
Prevent eval graph clicks from interrupting exploration

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     .move-item.featured:hover { background-color: rgba(250, 204, 21, 0.12); }
     .move-item.featured.highlight { background-color: #243249; }
     #eval-graph { cursor: pointer; transition: opacity 0.2s ease-in-out; }
-    #eval-graph.exploration-disabled { cursor: default; pointer-events: none; opacity: 0.85; }
+    #eval-graph.exploration-disabled { opacity: 0.85; }
     #move-analysis-scroll::-webkit-scrollbar { width: 8px; }
     #move-analysis-scroll::-webkit-scrollbar-track { background: #1a1f2a; }
     #move-analysis-scroll::-webkit-scrollbar-thumb { background-color: #4b5563; border-radius: 10px; border: 2px solid #1a1f2a; }
@@ -2046,10 +2046,8 @@ Finish with the Summary in the specified format; compute totals and accuracy exa
         if (!evalCanvas) return;
         if (isExploring()) {
           evalCanvas.classList.add('exploration-disabled');
-          evalCanvas.setAttribute('aria-disabled', 'true');
         } else {
           evalCanvas.classList.remove('exploration-disabled');
-          evalCanvas.removeAttribute('aria-disabled');
         }
       }
 
@@ -2059,9 +2057,7 @@ Finish with the Summary in the specified format; compute totals and accuracy exa
         evalCtx = evalCanvas.getContext('2d');
         evalCanvas.addEventListener('click', function(e) {
           if (isExploring()) {
-            e.preventDefault();
-            e.stopPropagation();
-            return;
+            clearExploration();
           }
           const rect = evalCanvas.getBoundingClientRect();
           const x = e.clientX - rect.left;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
     .move-item.featured { border: 1px solid rgba(250, 204, 21, 0.35); background-color: rgba(250, 204, 21, 0.06); }
     .move-item.featured:hover { background-color: rgba(250, 204, 21, 0.12); }
     .move-item.featured.highlight { background-color: #243249; }
+    #eval-graph { cursor: pointer; transition: opacity 0.2s ease-in-out; }
+    #eval-graph.exploration-disabled { cursor: default; pointer-events: none; opacity: 0.85; }
     #move-analysis-scroll::-webkit-scrollbar { width: 8px; }
     #move-analysis-scroll::-webkit-scrollbar-track { background: #1a1f2a; }
     #move-analysis-scroll::-webkit-scrollbar-thumb { background-color: #4b5563; border-radius: 10px; border: 2px solid #1a1f2a; }
@@ -653,6 +655,7 @@ Finish with the Summary in the specified format; compute totals and accuracy exa
         if (wasExploring || forceUpdate) {
           syncNavigationControls();
         }
+        updateEvalGraphInteractivity();
       }
 
       function applyExplorationCursor(targetCursor) {
@@ -1568,6 +1571,7 @@ Finish with the Summary in the specified format; compute totals and accuracy exa
         }
 
         function handleExplorationPositionChanged() {
+          updateEvalGraphInteractivity();
           if (!isExploring()) {
             syncNavigationControls();
             return;
@@ -2038,18 +2042,34 @@ Finish with the Summary in the specified format; compute totals and accuracy exa
         scroll.style.height = target + 'px';
       }
 
+      function updateEvalGraphInteractivity() {
+        if (!evalCanvas) return;
+        if (isExploring()) {
+          evalCanvas.classList.add('exploration-disabled');
+          evalCanvas.setAttribute('aria-disabled', 'true');
+        } else {
+          evalCanvas.classList.remove('exploration-disabled');
+          evalCanvas.removeAttribute('aria-disabled');
+        }
+      }
+
       function initEvalGraph() {
         evalCanvas = document.getElementById('eval-graph');
         if (!evalCanvas) return;
         evalCtx = evalCanvas.getContext('2d');
         evalCanvas.addEventListener('click', function(e) {
-          if (isExploring()) return;
+          if (isExploring()) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
           const rect = evalCanvas.getBoundingClientRect();
           const x = e.clientX - rect.left;
           const maxIdx = Math.max(probSeries.length - 1, 0);
           const idx = Math.round((x / evalCanvas.width) * maxIdx);
           goToMove(idx);
         });
+        updateEvalGraphInteractivity();
         resizeEvalGraph();
       }
 


### PR DESCRIPTION
## Summary
- add styling and state handling to disable evaluation graph interaction while exploring alternate lines
- prevent evaluation graph click handler from navigating away during exploration and sync accessibility state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97173e7148333a552092447f9ff33