### PR TITLE
Fix Lichess PGN fetch to include moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,6 @@
         const params = new URLSearchParams({
           max: '20',
           pgnInJson: 'true',
-          moves: 'false',
           clocks: 'false',
           evals: 'false',
           opening: 'false'


### PR DESCRIPTION
## Summary
- stop stripping move data when fetching Lichess games so imported PGNs are complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b8db07e083339082ca98b6df50f5