### PR TITLE
Add player coaching sentence to analysis prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,6 +1095,7 @@
 
       // Prompt (adds one-line Summary at the end)
       const ANALYSIS_PROMPT_TEMPLATE = `You are given:
+The player being coached is eugenime.
 1) A PGN with SAN moves and mover-centric deltas {…}.
 2) An “Automated Insights” block listing each half-move with its FINAL classification (Book, Good, Forced, Inaccuracy, Mistake, Blunder, Misclick??, Great, Brilliant).
 3) Precomputed Summary counts, Accuracy, Move of the game.


### PR DESCRIPTION
## Summary
- add an explicit sentence naming the coached player as eugenime in the analysis prompt template so the target replacement works

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e589d365a08333b1bb87877b62ffeb